### PR TITLE
Add shared EventBus application

### DIFF
--- a/apps/event_bus/README.md
+++ b/apps/event_bus/README.md
@@ -1,0 +1,3 @@
+# EventBus
+
+Shared PubSub for Helix umbrella.

--- a/apps/event_bus/lib/event_bus.ex
+++ b/apps/event_bus/lib/event_bus.ex
@@ -1,0 +1,11 @@
+defmodule EventBus do
+  @moduledoc """Simple wrapper around `Phoenix.PubSub` used across the umbrella."""
+
+  def publish({topic, message}) do
+    Phoenix.PubSub.broadcast(Helix.PubSub, topic, message)
+  end
+
+  def subscribe(topic) do
+    Phoenix.PubSub.subscribe(Helix.PubSub, topic)
+  end
+end

--- a/apps/event_bus/lib/event_bus/application.ex
+++ b/apps/event_bus/lib/event_bus/application.ex
@@ -1,0 +1,15 @@
+defmodule EventBus.Application do
+  @moduledoc false
+
+  use Application
+
+  @impl true
+  def start(_type, _args) do
+    children = [
+      {Phoenix.PubSub, name: Helix.PubSub, pool_size: 1}
+    ]
+
+    opts = [strategy: :one_for_one, name: EventBus.Supervisor]
+    Supervisor.start_link(children, opts)
+  end
+end

--- a/apps/event_bus/mix.exs
+++ b/apps/event_bus/mix.exs
@@ -1,0 +1,34 @@
+defmodule EventBus.MixProject do
+  use Mix.Project
+
+  def project do
+    [
+      app: :event_bus,
+      version: "0.1.0",
+      build_path: "../../_build",
+      config_path: "../../config/config.exs",
+      deps_path: "../../deps",
+      lockfile: "../../mix.lock",
+      elixir: "~> 1.18",
+      start_permanent: Mix.env() == :prod,
+      deps: deps(),
+      elixirc_paths: elixirc_paths(Mix.env())
+    ]
+  end
+
+  def application do
+    [
+      extra_applications: [:logger],
+      mod: {EventBus.Application, []}
+    ]
+  end
+
+  defp elixirc_paths(:test), do: ["lib"]
+  defp elixirc_paths(_env), do: ["lib"]
+
+  defp deps do
+    [
+      {:phoenix_pubsub, "~> 2.0"}
+    ]
+  end
+end

--- a/apps/memberships/lib/application.ex
+++ b/apps/memberships/lib/application.ex
@@ -8,7 +8,6 @@ defmodule Memberships.Application do
     children = [
       Memberships.Infrastructure.Db.Repo,
       # {Bandit, plug: Memberships.Http.Router, scheme: :http, port: 4001}
-      {Phoenix.PubSub, [name: Memberships.PubSub, pool_size: 1]},
       Memberships.Infrastructure.MembershipEventSubscriber
     ]
 

--- a/apps/memberships/lib/memberships/infrastructure/event_bus.ex
+++ b/apps/memberships/lib/memberships/infrastructure/event_bus.ex
@@ -1,5 +1,5 @@
 defmodule Memberships.EventBus do
   def publish(event) do
-    Phoenix.PubSub.broadcast(Memberships.PubSub, "membership_domain_events", event)
+    EventBus.publish({"membership_domain_events", event})
   end
 end

--- a/apps/memberships/lib/memberships/infrastructure/membership_projector.ex
+++ b/apps/memberships/lib/memberships/infrastructure/membership_projector.ex
@@ -7,7 +7,7 @@ defmodule Memberships.Infrastructure.MembershipEventSubscriber do
   def start_link(_), do: GenServer.start_link(__MODULE__, %{})
 
   def init(_) do
-    Phoenix.PubSub.subscribe(Memberships.PubSub, "membership_domain_events")
+    EventBus.subscribe("membership_domain_events")
     {:ok, %{}}
   end
 

--- a/apps/memberships/mix.exs
+++ b/apps/memberships/mix.exs
@@ -41,7 +41,7 @@ defmodule Memberships.MixProject do
       {:uuid, "~> 1.1"},
       {:ecto_sql, "~> 3.0"},
       {:postgrex, ">= 0.0.0"},
-      {:phoenix_pubsub, "~> 2.0"},
+      {:event_bus, in_umbrella: true},
       {:bandit, "~> 1.0"}
     ]
   end

--- a/apps/people/lib/people/application.ex
+++ b/apps/people/lib/people/application.ex
@@ -9,7 +9,6 @@ defmodule People.Application do
   def start(_type, _args) do
     children = [
       People.Infrastructure.Db.Repo,
-      {Phoenix.PubSub, [name: People.PubSub, pool_size: 1]},
       People.EventSubscriber,
       {Bandit, plug: People.Http.Router, scheme: :http, port: 4000}
     ]

--- a/apps/people/lib/people/infrastructure/event_bus.ex
+++ b/apps/people/lib/people/infrastructure/event_bus.ex
@@ -1,5 +1,5 @@
 defmodule People.EventBus do
   def publish(event) do
-    Phoenix.PubSub.broadcast(People.PubSub, "person_domain_events", event)
+    EventBus.publish({"person_domain_events", event})
   end
 end

--- a/apps/people/lib/people/infrastructure/person_projector.ex
+++ b/apps/people/lib/people/infrastructure/person_projector.ex
@@ -7,7 +7,7 @@ defmodule People.EventSubscriber do
   def start_link(_), do: GenServer.start_link(__MODULE__, %{})
 
   def init(_) do
-    Phoenix.PubSub.subscribe(People.PubSub, "person_domain_events")
+    EventBus.subscribe("person_domain_events")
     {:ok, %{}}
   end
 

--- a/apps/people/mix.exs
+++ b/apps/people/mix.exs
@@ -42,7 +42,7 @@ defmodule People.MixProject do
       {:uuid, "~> 1.1"},
       {:ecto_sql, "~> 3.0"},
       {:postgrex, ">= 0.0.0"},
-      {:phoenix_pubsub, "~> 2.0"},
+      {:event_bus, in_umbrella: true},
       {:bandit, "~> 1.0"}
     ]
   end

--- a/apps/people/test/infrastructure/person_repo_test.exs
+++ b/apps/people/test/infrastructure/person_repo_test.exs
@@ -18,7 +18,7 @@ defmodule People.Infrastructure.Repository.PersonWriteRepoTest do
       date_of_birth: %BirthDateValueObject{value: ~D[1990-01-01]}
     }
 
-    Phoenix.PubSub.subscribe(People.PubSub, "person_domain_events")
+    EventBus.subscribe("person_domain_events")
 
     {:ok, %{person: person}}
   end


### PR DESCRIPTION
## Summary
- introduce `event_bus` OTP app with Phoenix PubSub under `Helix.PubSub`
- expose `EventBus.publish/1` and `EventBus.subscribe/1`
- depend on the shared event bus in people and memberships apps
- use EventBus inside applications and tests

## Testing
- `mix test` *(fails: mix not installed)*

------
https://chatgpt.com/codex/tasks/task_e_683fee4efc0c832d91a3a389c646bb46